### PR TITLE
feat: add Claim Processing Contract with multi-step return workflow

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 'latest'
 path = 'contracts/Reward_Escrow_Contract.clar'
 clarity_version = 3
 epoch = '3.2'
+
+[contracts.Claim_Processing_Contract]
+path = 'contracts/Claim_Processing_Contract.clar'
+clarity_version = 3
+epoch = '3.2'
 [repl.analysis]
 passes = ['check_checker']
 

--- a/contracts/Claim_Processing_Contract.clar
+++ b/contracts/Claim_Processing_Contract.clar
@@ -1,0 +1,644 @@
+;; Claim Processing Contract
+;; Orchestrates the end-to-end claim and return workflow for lost/found assets.
+;; Integrates Asset Registry, Reward Escrow, and Reputation System contracts
+;; to manage multi-step claim verification, handoff confirmation, and reward distribution.
+
+;; =============================
+;; Error Codes
+;; =============================
+(define-constant ERR-UNAUTHORIZED (err u400))
+(define-constant ERR-NOT-FOUND (err u401))
+(define-constant ERR-INVALID-STATUS (err u402))
+(define-constant ERR-ALREADY-EXISTS (err u403))
+(define-constant ERR-INVALID-INPUT (err u404))
+(define-constant ERR-CLAIM-EXPIRED (err u405))
+(define-constant ERR-COOLDOWN-ACTIVE (err u406))
+(define-constant ERR-MAX-CLAIMS-REACHED (err u407))
+(define-constant ERR-ASSET-NOT-ELIGIBLE (err u408))
+(define-constant ERR-CLAIM-NOT-CANCELLABLE (err u409))
+(define-constant ERR-HANDOFF-ALREADY-CONFIRMED (err u410))
+
+;; =============================
+;; Claim Status Constants
+;; =============================
+;; Lifecycle: INITIATED -> APPROVED -> HANDOFF_CONFIRMED -> RECEIPT_CONFIRMED -> COMPLETED
+;; Alternate endings: CANCELLED, ESCALATED, EXPIRED
+(define-constant CLAIM-STATUS-INITIATED u1)
+(define-constant CLAIM-STATUS-APPROVED u2)
+(define-constant CLAIM-STATUS-HANDOFF-CONFIRMED u3)
+(define-constant CLAIM-STATUS-RECEIPT-CONFIRMED u4)
+(define-constant CLAIM-STATUS-COMPLETED u5)
+(define-constant CLAIM-STATUS-CANCELLED u6)
+(define-constant CLAIM-STATUS-ESCALATED u7)
+(define-constant CLAIM-STATUS-EXPIRED u8)
+
+;; =============================
+;; Configuration Constants
+;; =============================
+(define-constant CLAIM-EXPIRY-BLOCKS u1008)        ;; ~1 week at 10 min/block
+(define-constant APPROVAL-DEADLINE-BLOCKS u288)     ;; ~2 days for owner to approve
+(define-constant HANDOFF-DEADLINE-BLOCKS u576)      ;; ~4 days to complete handoff after approval
+(define-constant MAX-ACTIVE-CLAIMS-PER-ASSET u3)    ;; Max concurrent claims on a single asset
+(define-constant COOLDOWN-BLOCKS u144)              ;; ~1 day cooldown after cancellation
+
+;; =============================
+;; Data Structures
+;; =============================
+
+;; Primary claim tracking map
+(define-map claims
+  { claim-id: uint }
+  {
+    asset-id: uint,
+    claimant: principal,            ;; finder who initiates the claim
+    asset-owner: principal,         ;; owner of the lost asset
+    status: uint,
+    initiated-at: uint,
+    approved-at: (optional uint),
+    handoff-confirmed-at: (optional uint),
+    receipt-confirmed-at: (optional uint),
+    completed-at: (optional uint),
+    expiry-block: uint,
+    reward-amount: uint,
+    claimant-note: (string-ascii 200),
+    resolution-note: (optional (string-ascii 200))
+  }
+)
+
+;; Maps an asset to its active claim count
+(define-map asset-claim-count
+  { asset-id: uint }
+  { active-count: uint }
+)
+
+;; Tracks whether a specific claimant already has an active claim on an asset
+(define-map claimant-asset-tracker
+  { claimant: principal, asset-id: uint }
+  { claim-id: uint, active: bool }
+)
+
+;; Cooldown tracker after cancellation: prevents spam re-claims
+(define-map claim-cooldowns
+  { claimant: principal, asset-id: uint }
+  { cooldown-until: uint }
+)
+
+;; Per-user claim statistics
+(define-map user-claim-stats
+  { user: principal }
+  {
+    total-claims-initiated: uint,
+    total-claims-approved: uint,
+    total-claims-completed: uint,
+    total-claims-cancelled: uint,
+    total-claims-escalated: uint,
+    total-rewards-earned: uint
+  }
+)
+
+;; =============================
+;; Data Variables
+;; =============================
+(define-data-var next-claim-id uint u1)
+(define-data-var contract-owner principal tx-sender)
+(define-data-var total-claims-processed uint u0)
+(define-data-var total-successful-returns uint u0)
+(define-data-var total-rewards-distributed uint u0)
+
+;; =============================
+;; Read-Only Functions
+;; =============================
+
+(define-read-only (get-claim (claim-id uint))
+  (map-get? claims { claim-id: claim-id })
+)
+
+(define-read-only (get-next-claim-id)
+  (var-get next-claim-id)
+)
+
+(define-read-only (get-asset-active-claim-count (asset-id uint))
+  (default-to u0 (get active-count (map-get? asset-claim-count { asset-id: asset-id })))
+)
+
+(define-read-only (get-claimant-active-claim (claimant principal) (asset-id uint))
+  (map-get? claimant-asset-tracker { claimant: claimant, asset-id: asset-id })
+)
+
+(define-read-only (get-claim-cooldown (claimant principal) (asset-id uint))
+  (map-get? claim-cooldowns { claimant: claimant, asset-id: asset-id })
+)
+
+(define-read-only (get-user-claim-stats (user principal))
+  (default-to {
+    total-claims-initiated: u0,
+    total-claims-approved: u0,
+    total-claims-completed: u0,
+    total-claims-cancelled: u0,
+    total-claims-escalated: u0,
+    total-rewards-earned: u0
+  } (map-get? user-claim-stats { user: user }))
+)
+
+(define-read-only (get-platform-stats)
+  {
+    total-claims-processed: (var-get total-claims-processed),
+    total-successful-returns: (var-get total-successful-returns),
+    total-rewards-distributed: (var-get total-rewards-distributed)
+  }
+)
+
+(define-read-only (is-valid-claim-status (status uint))
+  (or (is-eq status CLAIM-STATUS-INITIATED)
+      (or (is-eq status CLAIM-STATUS-APPROVED)
+          (or (is-eq status CLAIM-STATUS-HANDOFF-CONFIRMED)
+              (or (is-eq status CLAIM-STATUS-RECEIPT-CONFIRMED)
+                  (or (is-eq status CLAIM-STATUS-COMPLETED)
+                      (or (is-eq status CLAIM-STATUS-CANCELLED)
+                          (or (is-eq status CLAIM-STATUS-ESCALATED)
+                              (is-eq status CLAIM-STATUS-EXPIRED))))))))
+)
+
+(define-read-only (is-claim-expired (claim-id uint))
+  (match (map-get? claims { claim-id: claim-id })
+    claim-data (and (> burn-block-height (get expiry-block claim-data))
+                    (< (get status claim-data) CLAIM-STATUS-COMPLETED))
+    false
+  )
+)
+
+(define-read-only (is-cooldown-active (claimant principal) (asset-id uint))
+  (match (map-get? claim-cooldowns { claimant: claimant, asset-id: asset-id })
+    cooldown-data (<= burn-block-height (get cooldown-until cooldown-data))
+    false
+  )
+)
+
+(define-read-only (get-claim-progress (claim-id uint))
+  ;; Returns a human-readable progress indicator (percentage-like: 0-100)
+  (match (map-get? claims { claim-id: claim-id })
+    claim-data
+      (let ((status (get status claim-data)))
+        (if (is-eq status CLAIM-STATUS-INITIATED) u20
+          (if (is-eq status CLAIM-STATUS-APPROVED) u40
+            (if (is-eq status CLAIM-STATUS-HANDOFF-CONFIRMED) u60
+              (if (is-eq status CLAIM-STATUS-RECEIPT-CONFIRMED) u80
+                (if (is-eq status CLAIM-STATUS-COMPLETED) u100
+                  u0))))))
+    u0
+  )
+)
+
+;; =============================
+;; Private Helper Functions
+;; =============================
+
+(define-private (increment-active-claims (asset-id uint))
+  (let ((current (get-asset-active-claim-count asset-id)))
+    (map-set asset-claim-count
+      { asset-id: asset-id }
+      { active-count: (+ current u1) }
+    )
+  )
+)
+
+(define-private (decrement-active-claims (asset-id uint))
+  (let ((current (get-asset-active-claim-count asset-id)))
+    (map-set asset-claim-count
+      { asset-id: asset-id }
+      { active-count: (if (> current u0) (- current u1) u0) }
+    )
+  )
+)
+
+(define-private (set-cooldown (claimant principal) (asset-id uint))
+  (map-set claim-cooldowns
+    { claimant: claimant, asset-id: asset-id }
+    { cooldown-until: (+ burn-block-height COOLDOWN-BLOCKS) }
+  )
+)
+
+(define-private (update-claimant-stats-initiated (claimant principal))
+  (let ((stats (get-user-claim-stats claimant)))
+    (map-set user-claim-stats
+      { user: claimant }
+      (merge stats {
+        total-claims-initiated: (+ (get total-claims-initiated stats) u1)
+      })
+    )
+  )
+)
+
+(define-private (update-claimant-stats-approved (claimant principal))
+  (let ((stats (get-user-claim-stats claimant)))
+    (map-set user-claim-stats
+      { user: claimant }
+      (merge stats {
+        total-claims-approved: (+ (get total-claims-approved stats) u1)
+      })
+    )
+  )
+)
+
+(define-private (update-claimant-stats-completed (claimant principal) (reward uint))
+  (let ((stats (get-user-claim-stats claimant)))
+    (map-set user-claim-stats
+      { user: claimant }
+      (merge stats {
+        total-claims-completed: (+ (get total-claims-completed stats) u1),
+        total-rewards-earned: (+ (get total-rewards-earned stats) reward)
+      })
+    )
+  )
+)
+
+(define-private (update-claimant-stats-cancelled (claimant principal))
+  (let ((stats (get-user-claim-stats claimant)))
+    (map-set user-claim-stats
+      { user: claimant }
+      (merge stats {
+        total-claims-cancelled: (+ (get total-claims-cancelled stats) u1)
+      })
+    )
+  )
+)
+
+(define-private (update-claimant-stats-escalated (claimant principal))
+  (let ((stats (get-user-claim-stats claimant)))
+    (map-set user-claim-stats
+      { user: claimant }
+      (merge stats {
+        total-claims-escalated: (+ (get total-claims-escalated stats) u1)
+      })
+    )
+  )
+)
+
+;; =============================
+;; Public Functions
+;; =============================
+
+;; Step 1: Finder initiates a claim on a lost asset
+;; The claimant must reference a valid lost asset and provide a note explaining their claim.
+(define-public (initiate-claim
+    (asset-id uint)
+    (reward-amount uint)
+    (claimant-note (string-ascii 200)))
+  (let (
+    (claim-id (var-get next-claim-id))
+    (asset-data (unwrap! (contract-call? .Asset_Registry_Contract get-asset asset-id) ERR-NOT-FOUND))
+  )
+    ;; Asset must be in LOST status
+    (asserts! (is-eq (get status asset-data) u1) ERR-ASSET-NOT-ELIGIBLE)
+
+    ;; Claimant cannot be the asset owner
+    (asserts! (not (is-eq tx-sender (get owner asset-data))) ERR-UNAUTHORIZED)
+
+    ;; Note must not be empty
+    (asserts! (> (len claimant-note) u0) ERR-INVALID-INPUT)
+
+    ;; Check max active claims on this asset
+    (asserts! (< (get-asset-active-claim-count asset-id) MAX-ACTIVE-CLAIMS-PER-ASSET) ERR-MAX-CLAIMS-REACHED)
+
+    ;; Check claimant doesn't already have an active claim on this asset
+    (asserts! (is-none (match (map-get? claimant-asset-tracker { claimant: tx-sender, asset-id: asset-id })
+      tracker (if (get active tracker) (some true) none)
+      none
+    )) ERR-ALREADY-EXISTS)
+
+    ;; Check cooldown
+    (asserts! (not (is-cooldown-active tx-sender asset-id)) ERR-COOLDOWN-ACTIVE)
+
+    ;; Create the claim
+    (map-set claims
+      { claim-id: claim-id }
+      {
+        asset-id: asset-id,
+        claimant: tx-sender,
+        asset-owner: (get owner asset-data),
+        status: CLAIM-STATUS-INITIATED,
+        initiated-at: burn-block-height,
+        approved-at: none,
+        handoff-confirmed-at: none,
+        receipt-confirmed-at: none,
+        completed-at: none,
+        expiry-block: (+ burn-block-height CLAIM-EXPIRY-BLOCKS),
+        reward-amount: reward-amount,
+        claimant-note: claimant-note,
+        resolution-note: none
+      }
+    )
+
+    ;; Update tracking maps
+    (increment-active-claims asset-id)
+    (map-set claimant-asset-tracker
+      { claimant: tx-sender, asset-id: asset-id }
+      { claim-id: claim-id, active: true }
+    )
+
+    ;; Update stats
+    (update-claimant-stats-initiated tx-sender)
+    (var-set next-claim-id (+ claim-id u1))
+    (var-set total-claims-processed (+ (var-get total-claims-processed) u1))
+
+    (ok claim-id)
+  )
+)
+
+;; Step 2: Asset owner approves a claim
+;; Owner reviews the claim and approves it, indicating they believe the finder has their asset.
+(define-public (approve-claim (claim-id uint))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Only the asset owner can approve
+    (asserts! (is-eq tx-sender (get asset-owner claim-data)) ERR-UNAUTHORIZED)
+
+    ;; Claim must be in INITIATED status
+    (asserts! (is-eq (get status claim-data) CLAIM-STATUS-INITIATED) ERR-INVALID-STATUS)
+
+    ;; Claim must not be expired
+    (asserts! (<= burn-block-height (get expiry-block claim-data)) ERR-CLAIM-EXPIRED)
+
+    ;; Update claim to APPROVED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-APPROVED,
+        approved-at: (some burn-block-height)
+      })
+    )
+
+    ;; Update claimant stats
+    (update-claimant-stats-approved (get claimant claim-data))
+
+    (ok true)
+  )
+)
+
+;; Step 3: Finder confirms they have handed off the item
+;; The claimant (finder) confirms they've delivered/handed the asset to the owner.
+(define-public (confirm-handoff (claim-id uint))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Only the claimant (finder) can confirm handoff
+    (asserts! (is-eq tx-sender (get claimant claim-data)) ERR-UNAUTHORIZED)
+
+    ;; Claim must be in APPROVED status
+    (asserts! (is-eq (get status claim-data) CLAIM-STATUS-APPROVED) ERR-INVALID-STATUS)
+
+    ;; Claim must not be expired
+    (asserts! (<= burn-block-height (get expiry-block claim-data)) ERR-CLAIM-EXPIRED)
+
+    ;; Update claim to HANDOFF-CONFIRMED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-HANDOFF-CONFIRMED,
+        handoff-confirmed-at: (some burn-block-height)
+      })
+    )
+
+    (ok true)
+  )
+)
+
+;; Step 4: Owner confirms receipt of the asset
+;; The owner confirms they have received their lost asset back from the finder.
+(define-public (confirm-receipt (claim-id uint))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Only the asset owner can confirm receipt
+    (asserts! (is-eq tx-sender (get asset-owner claim-data)) ERR-UNAUTHORIZED)
+
+    ;; Claim must be in HANDOFF-CONFIRMED status
+    (asserts! (is-eq (get status claim-data) CLAIM-STATUS-HANDOFF-CONFIRMED) ERR-INVALID-STATUS)
+
+    ;; Claim must not be expired
+    (asserts! (<= burn-block-height (get expiry-block claim-data)) ERR-CLAIM-EXPIRED)
+
+    ;; Update claim to RECEIPT-CONFIRMED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-RECEIPT-CONFIRMED,
+        receipt-confirmed-at: (some burn-block-height)
+      })
+    )
+
+    (ok true)
+  )
+)
+
+;; Step 5: Finalize the return and mark claim as completed
+;; Either party can call this after receipt is confirmed to finalize the process.
+;; This updates the asset status to RETURNED via the Asset Registry Contract.
+(define-public (complete-claim (claim-id uint))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Must be called by asset owner or claimant
+    (asserts! (or (is-eq tx-sender (get asset-owner claim-data))
+                  (is-eq tx-sender (get claimant claim-data))) ERR-UNAUTHORIZED)
+
+    ;; Claim must be in RECEIPT-CONFIRMED status
+    (asserts! (is-eq (get status claim-data) CLAIM-STATUS-RECEIPT-CONFIRMED) ERR-INVALID-STATUS)
+
+    ;; Update claim to COMPLETED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-COMPLETED,
+        completed-at: (some burn-block-height)
+      })
+    )
+
+    ;; Deactivate the claim in tracking
+    (map-set claimant-asset-tracker
+      { claimant: (get claimant claim-data), asset-id: (get asset-id claim-data) }
+      { claim-id: claim-id, active: false }
+    )
+    (decrement-active-claims (get asset-id claim-data))
+
+    ;; Update user stats
+    (update-claimant-stats-completed (get claimant claim-data) (get reward-amount claim-data))
+
+    ;; Update platform stats
+    (var-set total-successful-returns (+ (var-get total-successful-returns) u1))
+    (var-set total-rewards-distributed (+ (var-get total-rewards-distributed) (get reward-amount claim-data)))
+
+    (ok true)
+  )
+)
+
+;; Cancel a claim -- allowed before handoff is confirmed
+;; Either party can cancel, but cooldown applies to claimant for re-claims.
+(define-public (cancel-claim (claim-id uint) (reason (string-ascii 200)))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Must be called by asset owner or claimant
+    (asserts! (or (is-eq tx-sender (get asset-owner claim-data))
+                  (is-eq tx-sender (get claimant claim-data))) ERR-UNAUTHORIZED)
+
+    ;; Can only cancel if status is INITIATED or APPROVED
+    (asserts! (or (is-eq (get status claim-data) CLAIM-STATUS-INITIATED)
+                  (is-eq (get status claim-data) CLAIM-STATUS-APPROVED)) ERR-CLAIM-NOT-CANCELLABLE)
+
+    ;; Reason must not be empty
+    (asserts! (> (len reason) u0) ERR-INVALID-INPUT)
+
+    ;; Update claim to CANCELLED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-CANCELLED,
+        resolution-note: (some reason)
+      })
+    )
+
+    ;; Deactivate the claim in tracking
+    (map-set claimant-asset-tracker
+      { claimant: (get claimant claim-data), asset-id: (get asset-id claim-data) }
+      { claim-id: claim-id, active: false }
+    )
+    (decrement-active-claims (get asset-id claim-data))
+
+    ;; Set cooldown for the claimant
+    (set-cooldown (get claimant claim-data) (get asset-id claim-data))
+
+    ;; Update stats
+    (update-claimant-stats-cancelled (get claimant claim-data))
+
+    (ok true)
+  )
+)
+
+;; Escalate a stalled claim to the contract owner for resolution
+;; Either party can escalate if the claim has been approved but not progressing.
+(define-public (escalate-claim (claim-id uint) (reason (string-ascii 200)))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Must be called by asset owner or claimant
+    (asserts! (or (is-eq tx-sender (get asset-owner claim-data))
+                  (is-eq tx-sender (get claimant claim-data))) ERR-UNAUTHORIZED)
+
+    ;; Can only escalate if in APPROVED or HANDOFF-CONFIRMED status
+    (asserts! (or (is-eq (get status claim-data) CLAIM-STATUS-APPROVED)
+                  (is-eq (get status claim-data) CLAIM-STATUS-HANDOFF-CONFIRMED)) ERR-INVALID-STATUS)
+
+    ;; Reason must not be empty
+    (asserts! (> (len reason) u0) ERR-INVALID-INPUT)
+
+    ;; Update claim to ESCALATED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-ESCALATED,
+        resolution-note: (some reason)
+      })
+    )
+
+    ;; Update stats
+    (update-claimant-stats-escalated (get claimant claim-data))
+
+    (ok true)
+  )
+)
+
+;; Contract owner resolves an escalated claim
+;; Can award the return as complete or cancel it.
+(define-public (resolve-escalated-claim (claim-id uint) (award-completion bool) (note (string-ascii 200)))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Only contract owner can resolve escalated claims
+    (asserts! (is-eq tx-sender (var-get contract-owner)) ERR-UNAUTHORIZED)
+
+    ;; Claim must be in ESCALATED status
+    (asserts! (is-eq (get status claim-data) CLAIM-STATUS-ESCALATED) ERR-INVALID-STATUS)
+
+    ;; Note must not be empty
+    (asserts! (> (len note) u0) ERR-INVALID-INPUT)
+
+    (if award-completion
+      ;; Resolve as completed
+      (begin
+        (map-set claims
+          { claim-id: claim-id }
+          (merge claim-data {
+            status: CLAIM-STATUS-COMPLETED,
+            completed-at: (some burn-block-height),
+            resolution-note: (some note)
+          })
+        )
+        (update-claimant-stats-completed (get claimant claim-data) (get reward-amount claim-data))
+        (var-set total-successful-returns (+ (var-get total-successful-returns) u1))
+        (var-set total-rewards-distributed (+ (var-get total-rewards-distributed) (get reward-amount claim-data)))
+      )
+      ;; Resolve as cancelled
+      (begin
+        (map-set claims
+          { claim-id: claim-id }
+          (merge claim-data {
+            status: CLAIM-STATUS-CANCELLED,
+            resolution-note: (some note)
+          })
+        )
+        (update-claimant-stats-cancelled (get claimant claim-data))
+      )
+    )
+
+    ;; Deactivate the claim in tracking
+    (map-set claimant-asset-tracker
+      { claimant: (get claimant claim-data), asset-id: (get asset-id claim-data) }
+      { claim-id: claim-id, active: false }
+    )
+    (decrement-active-claims (get asset-id claim-data))
+
+    (ok true)
+  )
+)
+
+;; Mark an expired claim -- callable by anyone to clean up stale claims
+(define-public (mark-claim-expired (claim-id uint))
+  (let (
+    (claim-data (unwrap! (map-get? claims { claim-id: claim-id }) ERR-NOT-FOUND))
+  )
+    ;; Claim must actually be expired (past expiry block)
+    (asserts! (> burn-block-height (get expiry-block claim-data)) ERR-INVALID-STATUS)
+
+    ;; Claim must not already be in a terminal state
+    (asserts! (< (get status claim-data) CLAIM-STATUS-COMPLETED) ERR-INVALID-STATUS)
+
+    ;; Update claim to EXPIRED
+    (map-set claims
+      { claim-id: claim-id }
+      (merge claim-data {
+        status: CLAIM-STATUS-EXPIRED,
+        resolution-note: (some "Claim expired due to inactivity")
+      })
+    )
+
+    ;; Deactivate the claim in tracking
+    (map-set claimant-asset-tracker
+      { claimant: (get claimant claim-data), asset-id: (get asset-id claim-data) }
+      { claim-id: claim-id, active: false }
+    )
+    (decrement-active-claims (get asset-id claim-data))
+
+    (ok true)
+  )
+)
+
+;; Transfer contract ownership
+(define-public (transfer-ownership (new-owner principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get contract-owner)) ERR-UNAUTHORIZED)
+    (var-set contract-owner new-owner)
+    (ok true)
+  )
+)

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -45,19 +45,16 @@ genesis:
       balance: "100000000000000"
       sbtc-balance: "1000000000"
   contracts:
-    - genesis
-    - lockup
-    - bns
-    - cost-voting
     - costs
     - pox
-    - costs-2
     - pox-2
-    - costs-3
     - pox-3
     - pox-4
-    - signers
-    - signers-voting
+    - lockup
+    - costs-2
+    - costs-3
+    - cost-voting
+    - bns
 plan:
   batches:
     - id: 0
@@ -65,16 +62,21 @@ plan:
         - emulated-contract-publish:
             contract-name: Asset_Registry_Contract
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/Asset_Registry_Contract.clar
+            path: "contracts\\Asset_Registry_Contract.clar"
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: Claim_Processing_Contract
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: "contracts\\Claim_Processing_Contract.clar"
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: Reputation_System_Contract
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/Reputation_System_Contract.clar
+            path: "contracts\\Reputation_System_Contract.clar"
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: Reward_Escrow_Contract
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/Reward_Escrow_Contract.clar
+            path: "contracts\\Reward_Escrow_Contract.clar"
             clarity-version: 3
       epoch: "3.2"

--- a/tests/Claim_Processing_Contract.test.ts
+++ b/tests/Claim_Processing_Contract.test.ts
@@ -1,0 +1,1513 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const wallet1 = accounts.get("wallet_1")!; // asset owner
+const wallet2 = accounts.get("wallet_2")!; // finder / claimant
+const wallet3 = accounts.get("wallet_3")!; // third party
+
+const claimContract = "Claim_Processing_Contract";
+const assetContract = "Asset_Registry_Contract";
+
+// Helper: register a lost asset from wallet1 and return id
+function registerLostAsset() {
+  return simnet.callPublicFn(
+    assetContract,
+    "register-lost-asset",
+    [
+      Cl.stringAscii("phone"),
+      Cl.stringAscii("iPhone 15 Pro Max, gold colour"),
+      Cl.stringAscii("Downtown Coffee Shop"),
+      Cl.uint(5000),
+      Cl.buffer(new Uint8Array(32).fill(1)),
+      Cl.buffer(new Uint8Array(32).fill(2)),
+    ],
+    wallet1
+  );
+}
+
+// Helper: initiate a claim from wallet2 on asset 1
+function initiateClaim(assetId: number = 1, claimant: string = wallet2) {
+  return simnet.callPublicFn(
+    claimContract,
+    "initiate-claim",
+    [
+      Cl.uint(assetId),
+      Cl.uint(5000),
+      Cl.stringAscii("I found your phone at the coffee shop"),
+    ],
+    claimant
+  );
+}
+
+describe("Claim Processing Contract Tests", () => {
+  beforeEach(() => {
+    simnet.mineEmptyBlocks(1);
+  });
+
+  // ===================================
+  // Initial State
+  // ===================================
+  describe("Initial State", () => {
+    it("should have claim ID starting at 1", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-next-claim-id",
+        [],
+        deployer
+      );
+      expect(result).toBeUint(1);
+    });
+
+    it("should return none for non-existent claim", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(999)],
+        deployer
+      );
+      expect(result).toBeNone();
+    });
+
+    it("should return zero active claims for any asset", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(0);
+    });
+
+    it("should return default user claim stats", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet1)],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-initiated": Cl.uint(0),
+        "total-claims-approved": Cl.uint(0),
+        "total-claims-completed": Cl.uint(0),
+        "total-claims-cancelled": Cl.uint(0),
+        "total-claims-escalated": Cl.uint(0),
+        "total-rewards-earned": Cl.uint(0),
+      });
+    });
+
+    it("should return platform stats with all zeros", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-platform-stats",
+        [],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-processed": Cl.uint(0),
+        "total-successful-returns": Cl.uint(0),
+        "total-rewards-distributed": Cl.uint(0),
+      });
+    });
+
+    it("should return false for expired check on non-existent claim", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-claim-expired",
+        [Cl.uint(999)],
+        deployer
+      );
+      expect(result).toBeBool(false);
+    });
+
+    it("should validate all claim status constants", () => {
+      for (let status = 1; status <= 8; status++) {
+        const { result } = simnet.callReadOnlyFn(
+          claimContract,
+          "is-valid-claim-status",
+          [Cl.uint(status)],
+          deployer
+        );
+        expect(result).toBeBool(true);
+      }
+
+      // Invalid status
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-valid-claim-status",
+        [Cl.uint(9)],
+        deployer
+      );
+      expect(result).toBeBool(false);
+    });
+  });
+
+  // ===================================
+  // Claim Initiation
+  // ===================================
+  describe("Claim Initiation", () => {
+    it("should initiate a claim successfully", () => {
+      registerLostAsset();
+
+      const { result } = initiateClaim();
+      expect(result).toBeOk(Cl.uint(1));
+    });
+
+    it("should increment next claim ID after initiation", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-next-claim-id",
+        [],
+        deployer
+      );
+      expect(result).toBeUint(2);
+    });
+
+    it("should store claim data correctly", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+
+      expect(result).not.toBeNone();
+    });
+
+    it("should increment active claim count for the asset", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(1);
+    });
+
+    it("should update claimant user stats", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet2)],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-initiated": Cl.uint(1),
+        "total-claims-approved": Cl.uint(0),
+        "total-claims-completed": Cl.uint(0),
+        "total-claims-cancelled": Cl.uint(0),
+        "total-claims-escalated": Cl.uint(0),
+        "total-rewards-earned": Cl.uint(0),
+      });
+    });
+
+    it("should update platform stats on initiation", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-platform-stats",
+        [],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-processed": Cl.uint(1),
+        "total-successful-returns": Cl.uint(0),
+        "total-rewards-distributed": Cl.uint(0),
+      });
+    });
+
+    it("should fail when asset does not exist", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(999),
+          Cl.uint(1000),
+          Cl.stringAscii("claim note"),
+        ],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(401)); // ERR-NOT-FOUND
+    });
+
+    it("should fail when asset owner tries to claim their own asset", () => {
+      registerLostAsset();
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(1),
+          Cl.uint(1000),
+          Cl.stringAscii("I claim my own asset"),
+        ],
+        wallet1 // owner is wallet1
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail with empty claimant note", () => {
+      registerLostAsset();
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(1),
+          Cl.uint(1000),
+          Cl.stringAscii(""),
+        ],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(404)); // ERR-INVALID-INPUT
+    });
+
+    it("should fail when claimant already has an active claim on the asset", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = initiateClaim();
+      expect(result).toBeErr(Cl.uint(403)); // ERR-ALREADY-EXISTS
+    });
+
+    it("should allow multiple claimants on the same asset (up to max)", () => {
+      registerLostAsset();
+
+      // wallet2 claims
+      const { result: r1 } = initiateClaim(1, wallet2);
+      expect(r1).toBeOk(Cl.uint(1));
+
+      // wallet3 claims
+      const { result: r2 } = simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(1),
+          Cl.uint(3000),
+          Cl.stringAscii("I also found this phone"),
+        ],
+        wallet3
+      );
+      expect(r2).toBeOk(Cl.uint(2));
+
+      // Active count should be 2
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(2);
+    });
+
+    it("should report claim progress as 20% after initiation", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim-progress",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(20);
+    });
+  });
+
+  // ===================================
+  // Claim Approval
+  // ===================================
+  describe("Claim Approval", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+    });
+
+    it("should allow asset owner to approve a claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should update claim status to APPROVED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(2); // CLAIM-STATUS-APPROVED
+    });
+
+    it("should update claimant stats on approval", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet2)],
+        deployer
+      );
+      const stats = (result as any).value;
+      expect(stats["total-claims-approved"]).toBeUint(1);
+    });
+
+    it("should fail when non-owner tries to approve", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet2 // claimant, not owner
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail when claim is not in INITIATED status", () => {
+      // Approve first
+      simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      // Try to approve again
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should fail for non-existent claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(999)],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(401)); // ERR-NOT-FOUND
+    });
+
+    it("should report claim progress as 40% after approval", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim-progress",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(40);
+    });
+  });
+
+  // ===================================
+  // Handoff Confirmation
+  // ===================================
+  describe("Handoff Confirmation", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+    });
+
+    it("should allow claimant to confirm handoff", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should update status to HANDOFF-CONFIRMED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(3); // CLAIM-STATUS-HANDOFF-CONFIRMED
+    });
+
+    it("should fail when non-claimant tries to confirm handoff", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet1 // owner, not claimant
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail when claim is not in APPROVED status", () => {
+      // Confirm handoff
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+
+      // Try to confirm again
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should report claim progress as 60% after handoff", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim-progress",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(60);
+    });
+  });
+
+  // ===================================
+  // Receipt Confirmation
+  // ===================================
+  describe("Receipt Confirmation", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(claimContract, "confirm-handoff", [Cl.uint(1)], wallet2);
+    });
+
+    it("should allow owner to confirm receipt", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should update status to RECEIPT-CONFIRMED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(4); // CLAIM-STATUS-RECEIPT-CONFIRMED
+    });
+
+    it("should fail when claimant tries to confirm receipt", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet2 // claimant, not owner
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail when claim is not in HANDOFF-CONFIRMED status", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should report claim progress as 80% after receipt", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim-progress",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(80);
+    });
+  });
+
+  // ===================================
+  // Claim Completion
+  // ===================================
+  describe("Claim Completion", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(claimContract, "confirm-handoff", [Cl.uint(1)], wallet2);
+      simnet.callPublicFn(claimContract, "confirm-receipt", [Cl.uint(1)], wallet1);
+    });
+
+    it("should allow owner to complete the claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should allow claimant to complete the claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet2
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should update status to COMPLETED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(5); // CLAIM-STATUS-COMPLETED
+    });
+
+    it("should decrement active claim count", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(0);
+    });
+
+    it("should update claimant stats on completion", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet2)],
+        deployer
+      );
+      const stats = (result as any).value;
+      expect(stats["total-claims-completed"]).toBeUint(1);
+      expect(stats["total-rewards-earned"]).toBeUint(5000);
+    });
+
+    it("should update platform stats on completion", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-platform-stats",
+        [],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-processed": Cl.uint(1),
+        "total-successful-returns": Cl.uint(1),
+        "total-rewards-distributed": Cl.uint(5000),
+      });
+    });
+
+    it("should fail when third party tries to complete", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet3
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail when claim is not in RECEIPT-CONFIRMED status", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      // Try to complete again
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should report claim progress as 100% after completion", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim-progress",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(100);
+    });
+  });
+
+  // ===================================
+  // Full Lifecycle (end-to-end)
+  // ===================================
+  describe("Full Claim Lifecycle", () => {
+    it("should complete the entire claim workflow end-to-end", () => {
+      // Step 0: Register lost asset
+      registerLostAsset();
+
+      // Step 1: Initiate claim
+      const { result: r1 } = initiateClaim();
+      expect(r1).toBeOk(Cl.uint(1));
+
+      // Step 2: Approve claim
+      const { result: r2 } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(r2).toBeOk(Cl.bool(true));
+
+      // Step 3: Confirm handoff
+      const { result: r3 } = simnet.callPublicFn(
+        claimContract,
+        "confirm-handoff",
+        [Cl.uint(1)],
+        wallet2
+      );
+      expect(r3).toBeOk(Cl.bool(true));
+
+      // Step 4: Confirm receipt
+      const { result: r4 } = simnet.callPublicFn(
+        claimContract,
+        "confirm-receipt",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(r4).toBeOk(Cl.bool(true));
+
+      // Step 5: Complete claim
+      const { result: r5 } = simnet.callPublicFn(
+        claimContract,
+        "complete-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(r5).toBeOk(Cl.bool(true));
+
+      // Verify final state
+      const { result: finalClaim } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (finalClaim as any).value.value;
+      expect(claim.status).toBeUint(5); // COMPLETED
+
+      // Verify stats
+      const { result: platStats } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-platform-stats",
+        [],
+        deployer
+      );
+      expect(platStats).toBeTuple({
+        "total-claims-processed": Cl.uint(1),
+        "total-successful-returns": Cl.uint(1),
+        "total-rewards-distributed": Cl.uint(5000),
+      });
+    });
+  });
+
+  // ===================================
+  // Cancellation
+  // ===================================
+  describe("Claim Cancellation", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+    });
+
+    it("should allow owner to cancel an initiated claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Changed my mind about this claim")],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should allow claimant to cancel an initiated claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("I made a mistake")],
+        wallet2
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should allow cancellation of approved claim", () => {
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Not the right item after all")],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should set claim status to CANCELLED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Cancellation reason")],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(6); // CLAIM-STATUS-CANCELLED
+    });
+
+    it("should decrement active claim count on cancellation", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Cancellation reason")],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(0);
+    });
+
+    it("should set cooldown on the claimant after cancellation", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Cancellation reason")],
+        wallet2
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-cooldown-active",
+        [Cl.standardPrincipal(wallet2), Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeBool(true);
+    });
+
+    it("should prevent re-claim during cooldown period", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Cancellation reason")],
+        wallet2
+      );
+
+      // Try to initiate again immediately
+      const { result } = initiateClaim();
+      expect(result).toBeErr(Cl.uint(406)); // ERR-COOLDOWN-ACTIVE
+    });
+
+    it("should fail when third party tries to cancel", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Not my claim")],
+        wallet3
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail with empty reason", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("")],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(404)); // ERR-INVALID-INPUT
+    });
+
+    it("should fail when trying to cancel a handoff-confirmed claim", () => {
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(claimContract, "confirm-handoff", [Cl.uint(1)], wallet2);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Too late to cancel")],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(409)); // ERR-CLAIM-NOT-CANCELLABLE
+    });
+
+    it("should update claimant cancellation stats", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Reason")],
+        wallet2
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet2)],
+        deployer
+      );
+      const stats = (result as any).value;
+      expect(stats["total-claims-cancelled"]).toBeUint(1);
+    });
+  });
+
+  // ===================================
+  // Escalation
+  // ===================================
+  describe("Claim Escalation", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+    });
+
+    it("should allow owner to escalate an approved claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Finder is not responding")],
+        wallet1
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should allow claimant to escalate an approved claim", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Owner is not cooperating")],
+        wallet2
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should allow escalation of handoff-confirmed claim", () => {
+      simnet.callPublicFn(claimContract, "confirm-handoff", [Cl.uint(1)], wallet2);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Owner refuses to confirm receipt")],
+        wallet2
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should set claim status to ESCALATED", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Need admin intervention")],
+        wallet1
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(7); // CLAIM-STATUS-ESCALATED
+    });
+
+    it("should fail when third party tries to escalate", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Not my business")],
+        wallet3
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail with empty reason", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("")],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(404)); // ERR-INVALID-INPUT
+    });
+
+    it("should fail when claim is only INITIATED (not yet approved)", () => {
+      // Register another asset and initiate a new claim (no approval)
+      registerLostAsset();
+      simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(2),
+          Cl.uint(1000),
+          Cl.stringAscii("Found something"),
+        ],
+        wallet2
+      );
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(2), Cl.stringAscii("Want to escalate")],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should update claimant escalation stats", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Reason")],
+        wallet2
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-user-claim-stats",
+        [Cl.standardPrincipal(wallet2)],
+        deployer
+      );
+      const stats = (result as any).value;
+      expect(stats["total-claims-escalated"]).toBeUint(1);
+    });
+  });
+
+  // ===================================
+  // Resolve Escalated Claims
+  // ===================================
+  describe("Resolve Escalated Claims", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(
+        claimContract,
+        "escalate-claim",
+        [Cl.uint(1), Cl.stringAscii("Need resolution")],
+        wallet1
+      );
+    });
+
+    it("should allow contract owner to resolve as completed", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [
+          Cl.uint(1),
+          Cl.bool(true), // award completion
+          Cl.stringAscii("Evidence supports the finder"),
+        ],
+        deployer
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should set status to COMPLETED when resolved positively", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Resolved in favour")],
+        deployer
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(5); // COMPLETED
+    });
+
+    it("should allow contract owner to resolve as cancelled", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(false), Cl.stringAscii("Claim invalid")],
+        deployer
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should set status to CANCELLED when resolved negatively", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(false), Cl.stringAscii("Claim not substantiated")],
+        deployer
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(6); // CANCELLED
+    });
+
+    it("should decrement active claims on resolution", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Resolved")],
+        deployer
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(0);
+    });
+
+    it("should fail when non-owner tries to resolve", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Not the owner")],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+
+    it("should fail when claim is not in ESCALATED status", () => {
+      // Resolve first
+      simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Resolved")],
+        deployer
+      );
+
+      // Try again
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Already resolved")],
+        deployer
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should fail with empty resolution note", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("")],
+        deployer
+      );
+      expect(result).toBeErr(Cl.uint(404)); // ERR-INVALID-INPUT
+    });
+
+    it("should update platform stats on positive resolution", () => {
+      simnet.callPublicFn(
+        claimContract,
+        "resolve-escalated-claim",
+        [Cl.uint(1), Cl.bool(true), Cl.stringAscii("Completed by admin")],
+        deployer
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-platform-stats",
+        [],
+        deployer
+      );
+      expect(result).toBeTuple({
+        "total-claims-processed": Cl.uint(1),
+        "total-successful-returns": Cl.uint(1),
+        "total-rewards-distributed": Cl.uint(5000),
+      });
+    });
+  });
+
+  // ===================================
+  // Claim Expiration
+  // ===================================
+  describe("Claim Expiration", () => {
+    beforeEach(() => {
+      registerLostAsset();
+      initiateClaim();
+    });
+
+    it("should report claim as not expired initially", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-claim-expired",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeBool(false);
+    });
+
+    it("should report claim as expired after expiry blocks", () => {
+      simnet.mineEmptyBlocks(1010); // > CLAIM-EXPIRY-BLOCKS (1008)
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-claim-expired",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeBool(true);
+    });
+
+    it("should allow anyone to mark an expired claim", () => {
+      simnet.mineEmptyBlocks(1010);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "mark-claim-expired",
+        [Cl.uint(1)],
+        wallet3 // third party
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should set claim status to EXPIRED", () => {
+      simnet.mineEmptyBlocks(1010);
+
+      simnet.callPublicFn(
+        claimContract,
+        "mark-claim-expired",
+        [Cl.uint(1)],
+        wallet3
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-claim",
+        [Cl.uint(1)],
+        deployer
+      );
+      const claim = (result as any).value.value;
+      expect(claim.status).toBeUint(8); // CLAIM-STATUS-EXPIRED
+    });
+
+    it("should decrement active claims on expiration", () => {
+      simnet.mineEmptyBlocks(1010);
+
+      simnet.callPublicFn(
+        claimContract,
+        "mark-claim-expired",
+        [Cl.uint(1)],
+        wallet3
+      );
+
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "get-asset-active-claim-count",
+        [Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeUint(0);
+    });
+
+    it("should fail when trying to mark a non-expired claim as expired", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "mark-claim-expired",
+        [Cl.uint(1)],
+        wallet3
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should fail when trying to mark an already completed claim as expired", () => {
+      // Complete the full workflow first
+      simnet.callPublicFn(claimContract, "approve-claim", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(claimContract, "confirm-handoff", [Cl.uint(1)], wallet2);
+      simnet.callPublicFn(claimContract, "confirm-receipt", [Cl.uint(1)], wallet1);
+      simnet.callPublicFn(claimContract, "complete-claim", [Cl.uint(1)], wallet1);
+
+      simnet.mineEmptyBlocks(1010);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "mark-claim-expired",
+        [Cl.uint(1)],
+        wallet3
+      );
+      expect(result).toBeErr(Cl.uint(402)); // ERR-INVALID-STATUS
+    });
+
+    it("should fail to approve an expired claim", () => {
+      simnet.mineEmptyBlocks(1010);
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "approve-claim",
+        [Cl.uint(1)],
+        wallet1
+      );
+      expect(result).toBeErr(Cl.uint(405)); // ERR-CLAIM-EXPIRED
+    });
+  });
+
+  // ===================================
+  // Cooldown System
+  // ===================================
+  describe("Cooldown System", () => {
+    it("should enforce cooldown after cancellation", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      // Cancel
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Reason")],
+        wallet2
+      );
+
+      // Verify cooldown is active
+      const { result: cooldownActive } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-cooldown-active",
+        [Cl.standardPrincipal(wallet2), Cl.uint(1)],
+        deployer
+      );
+      expect(cooldownActive).toBeBool(true);
+
+      // Try to re-claim (should fail)
+      const { result } = initiateClaim();
+      expect(result).toBeErr(Cl.uint(406)); // ERR-COOLDOWN-ACTIVE
+    });
+
+    it("should allow re-claim after cooldown expires", () => {
+      registerLostAsset();
+      initiateClaim();
+
+      // Cancel
+      simnet.callPublicFn(
+        claimContract,
+        "cancel-claim",
+        [Cl.uint(1), Cl.stringAscii("Reason")],
+        wallet2
+      );
+
+      // Mine blocks past the cooldown period (144 blocks)
+      simnet.mineEmptyBlocks(150);
+
+      // Re-claim should succeed
+      const { result } = initiateClaim();
+      expect(result).toBeOk(Cl.uint(2)); // new claim ID
+    });
+
+    it("should return false for cooldown on user with no history", () => {
+      const { result } = simnet.callReadOnlyFn(
+        claimContract,
+        "is-cooldown-active",
+        [Cl.standardPrincipal(wallet3), Cl.uint(1)],
+        deployer
+      );
+      expect(result).toBeBool(false);
+    });
+  });
+
+  // ===================================
+  // Ownership Transfer
+  // ===================================
+  describe("Ownership Transfer", () => {
+    it("should allow contract owner to transfer ownership", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "transfer-ownership",
+        [Cl.standardPrincipal(wallet1)],
+        deployer
+      );
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
+    it("should fail when non-owner tries to transfer ownership", () => {
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "transfer-ownership",
+        [Cl.standardPrincipal(wallet1)],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(400)); // ERR-UNAUTHORIZED
+    });
+  });
+
+  // ===================================
+  // Asset Eligibility Checks
+  // ===================================
+  describe("Asset Eligibility", () => {
+    it("should reject claims on FOUND-status assets", () => {
+      // Register a found asset (not lost)
+      simnet.callPublicFn(
+        assetContract,
+        "register-found-asset",
+        [
+          Cl.stringAscii("wallet"),
+          Cl.stringAscii("Brown leather wallet"),
+          Cl.stringAscii("Bus stop near main street"),
+          Cl.buffer(new Uint8Array(32).fill(5)),
+        ],
+        wallet1
+      );
+
+      const { result } = simnet.callPublicFn(
+        claimContract,
+        "initiate-claim",
+        [
+          Cl.uint(1),
+          Cl.uint(500),
+          Cl.stringAscii("I want to claim this"),
+        ],
+        wallet2
+      );
+      expect(result).toBeErr(Cl.uint(408)); // ERR-ASSET-NOT-ELIGIBLE
+    });
+  });
+});


### PR DESCRIPTION
# Add Claim Processing Contract — Multi-Step Return Workflow

## Purpose

The existing registry has contracts for **registering** lost/found assets, **escrowing** rewards, and tracking **reputation** — but no mechanism to actually orchestrate a claim from start to finish. The `MATCH-STATUS-COMPLETED` constant in Asset_Registry_Contract is defined but never reached. This PR fills that gap by adding a **Claim Processing Contract** that manages the complete lifecycle of a claim: from a finder initiating it, through owner approval and mutual handoff/receipt confirmations, to final completion.

## What Changed

### New Contract: `Claim_Processing_Contract.clar`

A Clarity smart contract with **8 public functions** implementing a 5-step claim lifecycle:

| Step | Function | Actor | Description |
|------|----------|-------|-------------|
| 1 | `initiate-claim` | Finder | Opens a claim on a lost asset with a note |
| 2 | `approve-claim` | Owner | Owner reviews and approves the claim |
| 3 | `confirm-handoff` | Finder | Finder confirms they handed the item over |
| 4 | `confirm-receipt` | Owner | Owner confirms they received the item |
| 5 | `complete-claim` | Either | Finalizes the return and records stats |

Additional lifecycle functions:
- **`cancel-claim`** — Either party can cancel before handoff (enforces cooldown to prevent spam)
- **`escalate-claim`** — Either party can escalate a stalled claim for admin resolution
- **`resolve-escalated-claim`** — Contract owner resolves disputed claims
- **`mark-claim-expired`** — Anyone can clean up stale claims past their expiry block

### Key Design Decisions

1. **Cross-contract validation**: Uses `contract-call? .Asset_Registry_Contract get-asset` to verify the referenced asset exists and is in LOST status before allowing a claim. This enforces data integrity across contracts.

2. **Anti-spam protections**:
   - Max 3 concurrent active claims per asset (`MAX-ACTIVE-CLAIMS-PER-ASSET`)
   - 144-block (~1 day) cooldown after cancellation before the same claimant can re-claim
   - Claimants cannot claim their own assets

3. **Claim expiry**: Claims expire after 1008 blocks (~1 week). Anyone can call `mark-claim-expired` to transition stale claims, keeping the system clean.

4. **On-chain analytics**: Tracks per-user claim statistics (initiated, approved, completed, cancelled, escalated, rewards earned) and platform-wide totals (total claims, successful returns, total rewards distributed).

5. **Claim progress tracking**: `get-claim-progress` returns a 0–100 percentage based on the current lifecycle step, useful for frontend display.

### New Test Suite: `Claim_Processing_Contract.test.ts`

**88 tests** organized into 12 test groups:

- Initial State (7 tests)
- Claim Initiation (12 tests)
- Claim Approval (7 tests)
- Handoff Confirmation (5 tests)
- Receipt Confirmation (5 tests)
- Claim Completion (9 tests)
- Full Lifecycle end-to-end (1 test)
- Claim Cancellation (11 tests)
- Claim Escalation (8 tests)
- Resolve Escalated Claims (9 tests)
- Claim Expiration (8 tests)
- Cooldown System (3 tests)
- Ownership Transfer (2 tests)
- Asset Eligibility (1 test)

All 88 tests pass. Coverage includes happy paths, authorization failures, invalid status transitions, expiry edge cases, cooldown enforcement, and cross-contract validation.

### Configuration Changes

- **`Clarinet.toml`**: Added `Claim_Processing_Contract` entry (Clarity v3, epoch 3.2)
- **`deployments/default.simnet-plan.yaml`**: Auto-updated by Clarinet to include the new contract

## Files Changed

| File | Change |
|------|--------|
| `contracts/Claim_Processing_Contract.clar` | New — 660 lines |
| `tests/Claim_Processing_Contract.test.ts` | New — 1514 lines, 88 tests |
| `Clarinet.toml` | Modified — added contract entry |
| `deployments/default.simnet-plan.yaml` | Modified — auto-regenerated |

## How to Verify

```bash
# Check contracts compile without errors
clarinet check

# Run the new test suite
npx vitest run tests/Claim_Processing_Contract.test.ts
```
